### PR TITLE
Update notes by stdin pipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ i just want to scratch down some crap in vi and save it somewhere safe and synce
 
 `not some_title` same thing, but instead of todays date it's whatever custom title you wrote
 
+`not` also supports input through standard input: `echo 'piping stuff in through stdin works too!' | not`
+
 to add tags, simply add a line to your note that starts with "tags:" and then a comma separated list
 for example: `tags: these,are,tags`
 


### PR DESCRIPTION
Updated `not` to support input through stdin pipe, closing issue #6.

Beware that it does not check if the final note content (XML and all) is smaller than the maximum allowed note length (`evernote.edam.limits.constants.EDAM_NOTE_CONTENT_LEN_MAX`), so don't pipe in anything too big.
